### PR TITLE
accessing api directly (i.e. not via proxy)

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,7 +15,7 @@ export default new Vuex.Store({
     },
     actions: {
         getAllPosts({ commit }) {
-            axios.get('/api/v1/blog')
+            axios.get('http://billblog.development-server.info/api/v1/blog')
                 .then(result => commit('updatePosts', result.data))
                 .catch(console.error)
         },


### PR DESCRIPTION
Proxies are for development purposes only, and they are handled by webpack-dev-server. On production you need to make the calls to the actual host.